### PR TITLE
Clone method added to Request class definition

### DIFF
--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -15,6 +15,7 @@ declare class Request extends Body {
 	mode: string|RequestMode;
 	credentials: string|RequestCredentials;
 	cache: string|RequestCache;
+	clone(): Request;
 }
 
 interface RequestInit {


### PR DESCRIPTION
This method is needed to make a request clone with body on the original request object still intact.
